### PR TITLE
add “append” as synonym for “after” to type ‘a’/‘A’

### DIFF
--- a/Main.fs
+++ b/Main.fs
@@ -405,7 +405,9 @@ let normalMode =
             Optional count
             Choice [
                 Word ("after",                    "a",     Some "insert")
+                Word ("append",                   "a",     Some "insert")
                 Word ("after-line",               "A",     Some "insert")
+                Word ("append-line",              "A",     Some "insert")
                 Word ("insert",                   "i",     Some "insert")
                 Word ("insert-before-line",       "I",     Some "insert")
                 Word ("insert-column-zero",       "gI",    Some "insert")


### PR DESCRIPTION
That’s the word I think of for the `a` command. And the description in Vim’s `:help a` begins “<em>Append</em> text after the cursor …”, and `:help A` doesn’t include “after”, so I think “append” is the official name.

I haven’t ran the program to test this change. I just copied the format of the surrounding lines.
